### PR TITLE
Add time tolerance option for controlling merging of segments; plus breaking change

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,5 +6,10 @@
   functions.
 
 ## New features
+- `read_file`, `read_buffer`: The new `time_tolerance` keyword argument can
+  be used to control whether and how adjacent trace segments with gaps are
+  joined into a single segment.  (**N.B.** This feature can only be used
+  on x86 and x86_64 platforms due to JuliaLang/julia#27174 and
+  JuliaLang/julia#32154.)
 
 ## Notable bug fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,10 @@
+# LibMseed.jl v0.2.0 release notes
+
+## Breaking changes
+- `read_buffer`: The `verbose_level` positional argument has been replaced
+  with a keyword argument of the same name for consistency with other
+  functions.
+
+## New features
+
+## Notable bug fixes

--- a/src/c_types.jl
+++ b/src/c_types.jl
@@ -134,6 +134,11 @@ struct MS3TraceList
     last::Ptr{MS3TraceID}
 end
 
+struct MS3Tolerance
+    time::Ptr{Cvoid}
+    samprate::Ptr{Cvoid}
+end
+
 """
     init_tracelist(; verbose=false) -> mstl::Ptr{MS3TraceList}
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -70,27 +70,44 @@ function read_buffer(buffer::Vector{UInt8}, verbose_level=0)
 end
 
 """
-    read_file(file; verbose_level=0) -> tracelist
+    read_file(file; time_tolerance=nothing, verbose_level=0) -> tracelist
 
 Read miniSEED data from `file` on disk and return `tracelist`, (a
 `MseedTraceList`) containing the data.
 
 If `file` does not contain valid data then an error is thrown.
 
+By default, trace segments with gaps of less than half the nominal sampling
+interval are joined together to form a single segment.  This behaviour
+can be adjusted by passing a value in seconds to `time_tolerance`, in which
+case segments with gaps of less than `time_tolerance` s are joined.  Pass
+`time_tolerance = 0` to not merge segments with gaps.
+
+!!! note
+    `time_tolerance` can only be used on x86 and x64 platforms.  It is not
+    possible to use it on PowerPC or ARM processors such as Apple Silicon ones.
+    Users of these platforms will need to accept the default behaviour
+    and manually join segments separated with gaps larger than the default
+    tolerance.  See the note at
+    https://docs.julialang.org/en/v1/manual/calling-c-and-fortran-code/#Closure-cfunctions .
+
 `verbose_level` is passed to the `libmseed` routine `mstl3_readtracelist`
 to control the verbosity level, with `0` (the default) only writing
 error messages to stderr, and higher numbers causing more information
 to be printed.
 """
-function read_file(file; verbose_level=0)
+function read_file(file; time_tolerance=nothing, verbose_level=0)
     flags = MSF_VALIDATECRC | MSF_UNPACKDATA
     mstl = Ref(init_tracelist())
-    GC.@preserve mstl begin
+
+    time_tol_func_ptr, tolerance = _get_time_tolerance_func_ptr(time_tolerance)
+
+    GC.@preserve mstl time_tol_func_ptr begin
         err = ccall(
             (:ms3_readtracelist, libmseed),
             Cint,
-            (Ref{Ptr{MS3TraceList}}, Cstring, Ptr{Cvoid}, Int8, UInt32, Int8),
-            mstl[], file, C_NULL, -1, flags, verbose_level
+            (Ref{Ptr{MS3TraceList}}, Cstring, Ptr{MS3Tolerance}, Int8, UInt32, Int8),
+            mstl[], file, tolerance, -1, flags, verbose_level
         )
         if err != MS_NOERROR
             free!(mstl)
@@ -370,3 +387,33 @@ function check_error_value_and_warn(err, file=nothing)
 end
 
 _file_message(file) = file !== nothing ? " in file '$file'" : ""
+
+"""
+    _get_time_tolerance_func_ptr(time_tolerance) -> func_pointer, tolerance::MS3Tolerance
+
+If `time_tolerance` is not `nothing`, create a closure over
+`time_tolerance` and return a `Base.CFunction` and an `MS3Tolerance`
+containing a reference to
+
+`func_pointer` should be guarded in a `Base.@GC_preserve` block when
+`tolerance` is used to avoid the former being garbage collected.
+"""
+function _get_time_tolerance_func_ptr(time_tolerance)
+    time_tol_func_ptr = if time_tolerance !== nothing
+        # Create a closure to pass to libmseed to set the time tolerance by
+        # which traces are joined up.
+        time_tolerance_func(::Ptr{MS3Record})::Cdouble = time_tolerance
+        # Pointer to put in MS3Tolerance struct
+        @cfunction($time_tolerance_func, Cdouble, (Ptr{MS3Record},))
+    else
+        # Otherwise use default
+        C_NULL
+    end
+
+    tolerance = Ref(MS3Tolerance(
+        Base.unsafe_convert(Ptr{Cvoid}, time_tol_func_ptr),
+        C_NULL)
+    )
+
+    time_tol_func_ptr, tolerance
+end


### PR DESCRIPTION
- read_file: Add `time_tolerance` option to control segment merging
- read_buffer: Add `time_tolerance` option to control segment merging
- read_{file,buffer}: Throw an error using time_tolerance on ARM, PPC
- Add NEWS.md item for `time_tolerance` argument to `read_{file,buffer}`
