### PR TITLE
Fix bug when splitting channel ids into separate codes when the network code is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # LibMseed.jl
 
 [![Build Status](https://github.com/anowacki/LibMseed.jl/workflows/CI/badge.svg)](https://github.com/anowacki/LibMseed.jl/actions)
-[![Code coverage](https://codecov.io/gh/anowacki/LibMseed.jl/branch/master/graph/badge.svg?token=4XkpiFaFJN)](https://codecov.io/gh/anowacki/LibMseed.jl)
+[![Code coverage](https://codecov.io/gh/anowacki/LibMseed.jl/branch/main/graph/badge.svg?token=zZLUNA3tJk)](https://codecov.io/gh/anowacki/LibMseed.jl)
 
 LibMseed.jl is a Julia wrapper around the
 [libmseed](https://github.com/iris-edu/libmseed) library for reading

--- a/src/channel_codes.jl
+++ b/src/channel_codes.jl
@@ -20,7 +20,6 @@ function channel_code_parts(s::String)
     if startswith(s, "XFDSN:") || startswith(s, "FDSN:")
         # Seems like an XFDSN URN
         if length(s) > 6
-            length(parts[1]) > 6 || error("unexpectedly short network name")
             # URN convention: XFDSN:NET_STA_LOC_BAND_SOURCE_POSITION
             if nparts == 6
                 net = parts[1][1] == 'X' ? parts[1][7:end] : parts[1][6:end]

--- a/test/channel_codes.jl
+++ b/test/channel_codes.jl
@@ -24,10 +24,18 @@ using Test
             # Not enough parts
             @test_throws ErrorException LibMseed.channel_code_parts("XFDSN:A_B_C_D_E")
             @test_throws ErrorException LibMseed.channel_code_parts("FDSN:A_B_C_D_E")
+            # Empty network code
+            @test LibMseed.channel_code_parts("FDSN:_BB_CC_D_E_F") ==
+                (net="", sta="BB", loc="CC", cha="DEF")
+            @test LibMseed.channel_code_parts("XFDSN:_BB_CC_D_E_F") ==
+                (net="", sta="BB", loc="CC", cha="DEF")
+            # 'Empty' everything
+            @test LibMseed.channel_code_parts("XFDSN:___ _ _ ") ==
+                (net="", sta="", loc="", cha="   ")
         end
 
         @testset "_ separated" begin
-                # New format: separate channel code elements
+            # New format: separate channel code elements
             @test LibMseed.channel_code_parts("AA_BB_CC_D_E_F") ==
                 (net="AA", sta="BB", loc="CC", cha="DEF")
             # Old format: single channel code


### PR DESCRIPTION
- Fix Codecov badge in README
- channel_code_parts: Fix bug for empty network codes
