### PR TITLE
Upgrade libmseed library to v3.0.16

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,20 @@
+# LibMseed.jl v0.3.0 release notes
+
+## libmseed library version
+
+- libmseed version v3.0.16 is required.  This is the first stable
+  version of libmseed v3.
+
+
+# LibMseed.jl v0.2.2 release notes
+
+v0.2.2 is a final patch release before v0.3.  The release fixes
+compatibility with only v3.0.10 of the libmseed library.
+
+Users are encouraged to upgrade to v0.3 of LibMseed.jl, which
+contains no changes to the public API.
+
+
 # LibMseed.jl v0.2.1 release notes
 
 ## Notable bug fixes

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LibMseed"
 uuid = "1f77302d-495a-4b02-8d15-b81beb84162e"
 authors = ["Andy Nowacki <a.nowacki@leeds.ac.uk>"]
-version = "0.2.1"
+version = "0.3.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -9,7 +9,7 @@ libmseed_jll = "ccc2c699-b150-5417-88f2-a95a0d1581d9"
 
 [compat]
 julia = "1.6"
-libmseed_jll = "3.0.10"
+libmseed_jll = "3.0.16"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -15,8 +15,11 @@ and writing data in the miniSEED format.
 You can install LibMseed.jl from Julia's package manager like so:
 
 ```julia
-julia> using Pkg; Pkg.add(url="https://github.com/anowacki/LibMseed.jl")
+julia> using Pkg; Pkg.add("LibMseed")
 ```
+
+You do not need to separately install the `libmseed` library.  Instead,
+LibMseed.jl installs its own version automatically.
 
 ## Using the package
 
@@ -40,7 +43,7 @@ MseedTraceList:
 ```
 
 ### Reading data from memory
-Use the unexported `LibMseed.read_buffer` function to read miniSEED data
+Use the `LibMseed.read_buffer` function to read miniSEED data
 from memory.  This data should be a `Vector` of `UInt8`s.
 
 ```julia
@@ -118,7 +121,7 @@ set to `nothing`.
 
 ### Writing data
 To write a continuous set of evenly-spaced samples to disk in miniSEED
-format, use the unexported `LibMseed.write_file` function.
+format, use the `LibMseed.write_file` function.
 
 Here we create some random data, set the necessary parameters (including
 the date of the first sample) and write it to a new file, `"example2.mseed"`.

--- a/src/c_types.jl
+++ b/src/c_types.jl
@@ -48,11 +48,11 @@ const MSF_MAINTAINMSTL = 0x0200
 const nstime_t = Int64
 
 # C structs used for libmseed
-struct MS3Record
+@eval struct MS3Record
     record::Cstring
     reclen::Int32
     swapflag::UInt8
-    sid::NTuple{64, UInt8}
+    sid::NTuple{$LM_SIDLEN, UInt8}
     formatversion::UInt8
     flags::UInt8
     starttime::nstime_t
@@ -116,8 +116,10 @@ struct MS3TraceSeg
     next::Ptr{MS3TraceSeg}
 end
 
-struct MS3TraceID
-    sid::NTuple{64, UInt8}
+const MSTRACEID_SKIPLIST_HEIGHT = 8
+
+@eval struct MS3TraceID
+    sid::NTuple{$LM_SIDLEN, UInt8}
     pubversion::UInt8
     earliest::nstime_t
     latest::nstime_t
@@ -125,13 +127,14 @@ struct MS3TraceID
     numsegments::UInt32
     first::Ptr{MS3TraceSeg}
     last::Ptr{MS3TraceSeg}
-    next::Ptr{MS3TraceID}
+    next::NTuple{$MSTRACEID_SKIPLIST_HEIGHT, Ptr{MS3TraceID}}
+    height::UInt8
 end
 
 struct MS3TraceList
-    numtraces::UInt32
-    traces::Ptr{MS3TraceID}
-    last::Ptr{MS3TraceID}
+    numtraceids::UInt32
+    traces::MS3TraceID
+    prngstate::UInt64
 end
 
 struct MS3Tolerance

--- a/src/io.jl
+++ b/src/io.jl
@@ -402,7 +402,7 @@ _file_message(file) = file !== nothing ? " in file '$file'" : ""
 
 If `time_tolerance` is not `nothing`, create a closure over
 `time_tolerance` and return a `Base.CFunction` and an `MS3Tolerance`
-containing a reference to
+containing a reference to the function.
 
 `func_pointer` should be guarded in a `Base.@GC_preserve` block when
 `tolerance` is used to avoid the former being garbage collected.

--- a/src/nanoseconddatetime.jl
+++ b/src/nanoseconddatetime.jl
@@ -17,6 +17,10 @@ to the millisecond resolution that `DateTime` offers.
 # Other functions
 - [`nearest_datetime`](@ref): Return the `Dates.DateTime` nearest to the
   `NanosecondDateTime`.
+
+# Extended `Dates` functions
+- `Date`: Return the `Date` part of a `NanosecondDateTime`.
+- `Time`: Return the `Time` part of a `NanosecondDateTime` to full ns precision.
 """
 struct NanosecondDateTime
     "`DateTime`, to millisecond resolution"

--- a/test/julia_types.jl
+++ b/test/julia_types.jl
@@ -1,0 +1,12 @@
+using Test
+using LibMseed
+
+@testset "MseedTraceList" begin
+    @testset "Construction" begin
+        @testset "Errors" begin
+            @test_throws ArgumentError MseedTraceList(
+                Ref(Ptr{LibMseed.MS3TraceList}(C_NULL))
+            )
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Test
 
 @testset "All tests" begin
     include("nanoseconddatetime.jl")
+    include("julia_types.jl")
     include("io.jl")
     include("channel_codes.jl")
 end


### PR DESCRIPTION
The new v3.0.16 of libmseed has a different API to the previous
unstable v3 versions, so a minor upgrade of the library is needed.

- Update installation instructions since the package is registered.
- Update C types to match new libmseed structs.
- Add tests for Julia type constructors.
