### PR TITLE
Return documented things in channel_code_parts and don't throw errors

### DIFF
--- a/src/channel_codes.jl
+++ b/src/channel_codes.jl
@@ -1,11 +1,14 @@
 # Utilities for dealing with channel codes/trace IDs
 
 """
-    channel_code_parts(s) (net, sta, loc, cha)
+    channel_code_parts(s) -> (net, sta, loc, cha)
 
 Convert a single `String` `s` into its component SEED channel code parts.
 Returns a named tuple of network `net`, station `sta`, location `loc` and
 channel `cha`.  Empty components are given as empty `String`s.
+
+If the channel code does not appear to match any known pattern, `s` is
+returned in `sta` and all other parts are empty.
 
 This function assumes that `s` is an ASCII string, as per the SEED convention
 for channel IDs.
@@ -28,17 +31,20 @@ function channel_code_parts(s::String)
                 cha = join(parts[4:end])
             # Traditional SEED convention: NET_STA_LOC_CHA
             elseif nparts == 4
-                length(parts[1]) > 6 || error("unexpectedly short network name")
                 net = parts[1][1] == 'X' ? parts[1][7:end] : parts[1][6:end]
                 sta = parts[2]
                 loc = parts[3]
                 cha = parts[4]
             else
-                error("unexpected apparent XFDSN URN")
+                @warn("unexpected apparent XFDSN URN")
+                net = loc = cha = ""
+                sta = s
             end
         # Not really an XFDSN URN
         else
-            error("unexpectedly short channel id")
+            @warn("unexpectedly short channel id")
+            net = loc = cha = ""
+            sta = s
         end
 
     # Not an XFDSN URN but might have the same structure
@@ -57,10 +63,10 @@ function channel_code_parts(s::String)
             cha = join(parts[4:end])
         # Something else entirely: just put it all in sta
         else
-            net = nothing
+            net = ""
             sta = s
-            loc = nothing
-            cha = nothing
+            loc = ""
+            cha = ""
         end
     end
     (net=net, sta=sta, loc=loc, cha=cha)

--- a/test/channel_codes.jl
+++ b/test/channel_codes.jl
@@ -5,33 +5,68 @@ using Test
 @testset "Channel codes" begin
     @testset "channel_code_parts" begin
         @testset "FDSN format" begin
-            # New format: separate channel code elements
-            @test LibMseed.channel_code_parts("XFDSN:AA_BB_CC_D_E_F") ==
-                (net="AA", sta="BB", loc="CC", cha="DEF")
-            @test LibMseed.channel_code_parts("FDSN:AA_BB_CC_D_E_F") ==
-                (net="AA", sta="BB", loc="CC", cha="DEF")
-            # Old format: single channel code
-            @test LibMseed.channel_code_parts("XFDSN:AA_BB_CC_DEF") ==
-                (net="AA", sta="BB", loc="CC", cha="DEF")
-            @test LibMseed.channel_code_parts("FDSN:AA_BB_CC_DEF") ==
-                (net="AA", sta="BB", loc="CC", cha="DEF")
-            # No _s
-            @test_throws ErrorException LibMseed.channel_code_parts("XFDSN:ldfjaldjjlfjk")
-            @test_throws ErrorException LibMseed.channel_code_parts("FDSN:ldfjaldjjlfjk")
-            # Too many parts
-            @test_throws ErrorException LibMseed.channel_code_parts("XFDSN:A_B_C_D_E_F_G")
-            @test_throws ErrorException LibMseed.channel_code_parts("FDSN:A_B_C_D_E_F_G")
-            # Not enough parts
-            @test_throws ErrorException LibMseed.channel_code_parts("XFDSN:A_B_C_D_E")
-            @test_throws ErrorException LibMseed.channel_code_parts("FDSN:A_B_C_D_E")
-            # Empty network code
-            @test LibMseed.channel_code_parts("FDSN:_BB_CC_D_E_F") ==
-                (net="", sta="BB", loc="CC", cha="DEF")
-            @test LibMseed.channel_code_parts("XFDSN:_BB_CC_D_E_F") ==
-                (net="", sta="BB", loc="CC", cha="DEF")
-            # 'Empty' everything
-            @test LibMseed.channel_code_parts("XFDSN:___ _ _ ") ==
-                (net="", sta="", loc="", cha="   ")
+            @testset "New format: separate channel code elements" begin
+                @test LibMseed.channel_code_parts("XFDSN:AA_BB_CC_D_E_F") ==
+                    (net="AA", sta="BB", loc="CC", cha="DEF")
+                @test LibMseed.channel_code_parts("FDSN:AA_BB_CC_D_E_F") ==
+                    (net="AA", sta="BB", loc="CC", cha="DEF")
+                # Old format: single channel code
+                @test LibMseed.channel_code_parts("XFDSN:AA_BB_CC_DEF") ==
+                    (net="AA", sta="BB", loc="CC", cha="DEF")
+                @test LibMseed.channel_code_parts("FDSN:AA_BB_CC_DEF") ==
+                    (net="AA", sta="BB", loc="CC", cha="DEF")
+            end
+
+            @testset "No _s" begin
+                @test (
+                    @test_logs (
+                        :warn, "unexpected apparent XFDSN URN"
+                    ) LibMseed.channel_code_parts("XFDSN:ldfjaldjjlfjk")
+                ) == (net="", sta="XFDSN:ldfjaldjjlfjk", loc="", cha="")
+                @test (
+                    @test_logs (
+                        :warn, "unexpected apparent XFDSN URN"
+                    ) LibMseed.channel_code_parts("FDSN:ldfjaldjjlfjk")
+                ) == (net="", sta="FDSN:ldfjaldjjlfjk", loc="", cha="")
+            end
+            
+            @testset "Too many parts" begin
+                @test (
+                    @test_logs (
+                        :warn, "unexpected apparent XFDSN URN"
+                    ) LibMseed.channel_code_parts("XFDSN:A_B_C_D_E_F_G")
+                ) == (net="", sta="XFDSN:A_B_C_D_E_F_G", loc="", cha="")
+                @test (
+                    @test_logs (
+                        :warn, "unexpected apparent XFDSN URN"
+                    ) LibMseed.channel_code_parts("FDSN:A_B_C_D_E_F_G")
+                ) == (net="", sta="FDSN:A_B_C_D_E_F_G", loc="", cha="")
+            end
+
+            @testset "Not enough parts" begin
+                @test (
+                    @test_logs (
+                        :warn, "unexpected apparent XFDSN URN"
+                    ) LibMseed.channel_code_parts("XFDSN:A_B_C_D_E")
+                ) == (net="", sta="XFDSN:A_B_C_D_E", loc="", cha="")
+                @test (
+                    @test_logs (
+                        :warn, "unexpected apparent XFDSN URN"
+                    ) LibMseed.channel_code_parts("FDSN:A_B_C_D_E")
+                ) == (net="", sta="FDSN:A_B_C_D_E", loc="", cha="")
+            end
+
+            @testset "Empty network code" begin
+                @test LibMseed.channel_code_parts("FDSN:_BB_CC_D_E_F") ==
+                    (net="", sta="BB", loc="CC", cha="DEF")
+                @test LibMseed.channel_code_parts("XFDSN:_BB_CC_D_E_F") ==
+                    (net="", sta="BB", loc="CC", cha="DEF")
+            end
+
+            @testset "'Empty' everything" begin
+                @test LibMseed.channel_code_parts("XFDSN:___ _ _ ") ==
+                    (net="", sta="", loc="", cha="   ")
+            end
         end
 
         @testset "_ separated" begin
@@ -45,7 +80,7 @@ using Test
 
         @testset "Other format" begin
             @test LibMseed.channel_code_parts("AABBCCDEF") ==
-                (net=nothing, sta="AABBCCDEF", loc=nothing, cha=nothing)
+                (net="", sta="AABBCCDEF", loc="", cha="")
         end
 
         @testset "MseedTraceID" begin

--- a/test/channel_codes.jl
+++ b/test/channel_codes.jl
@@ -67,6 +67,19 @@ using Test
                 @test LibMseed.channel_code_parts("XFDSN:___ _ _ ") ==
                     (net="", sta="", loc="", cha="   ")
             end
+
+            @testset "Empty after '[X]FDSN:'" begin
+                @test (
+                    @test_logs (
+                        :warn, "unexpectedly short channel id"
+                    ) LibMseed.channel_code_parts("XFDSN:")
+                ) == (net="", sta="XFDSN:", loc="", cha="")
+                @test (
+                    @test_logs (
+                        :warn, "unexpectedly short channel id"
+                    ) LibMseed.channel_code_parts("FDSN:")
+                ) == (net="", sta="FDSN:", loc="", cha="")
+            end
         end
 
         @testset "_ separated" begin


### PR DESCRIPTION
Previously, `channel_code_parts`'s returned elements of a channel code
as `nothing` if they were empty in a miniSEED code string, or if the
format was not as expected.  However, the docstring actually stated they
would be 'empty', meaning empty strings.  Update the behaviour to match
that documented.

At the same time, also stop erroring when encountering a channel code
which for any reason does not fit the expected formats.  This is much
preferable because otherwise it is impossible to get the string out
of LibMseed.
