### PR TITLE
Update module to work with libmseed v3.0.18

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ libmseed_jll = "ccc2c699-b150-5417-88f2-a95a0d1581d9"
 
 [compat]
 julia = "1.6"
-libmseed_jll = "3.0.16"
+libmseed_jll = "3.0.18"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/c_types.jl
+++ b/src/c_types.jl
@@ -62,7 +62,7 @@ const nstime_t = Int64
     samplecnt::Int64
     crc::UInt32
     extralength::UInt16
-    datalength::UInt16
+    datalength::UInt32
     extra::Cstring
     datasamples::Ptr{Cvoid}
     datasize::Csize_t


### PR DESCRIPTION
libmseed v3.0.18 *despite supposed semver compliance* makes
breaking changes to the API, and so we must update some structures
in LibMseed.  Therefore this version of the package is only
compatible with v3.0.18 of libmseed.
