### PR TITLE
Enforce NanosecondDateTimes to be in the right range

### DIFF
--- a/test/nanoseconddatetime.jl
+++ b/test/nanoseconddatetime.jl
@@ -23,6 +23,12 @@ using Test
         @testset "NanosecondDateTime" begin
             dt = LibMseed.NanosecondDateTime(now(), Nanosecond(123456))
             @test dt == LibMseed.NanosecondDateTime(dt)
+            @test_throws ArgumentError LibMseed.NanosecondDateTime(
+                now(), Nanosecond(-1)
+            )
+            @test_throws ArgumentError LibMseed.NanosecondDateTime(
+                now(), Nanosecond(1_000_000)
+            )
         end
 
         @testset "String" begin
@@ -61,6 +67,11 @@ using Test
             ndt = LibMseed.NanosecondDateTime(i)
             i′ = convert(Int64, ndt)
             @test i == i′
+        end
+
+        @testset "Out of range conversion" begin
+            @test_throws InexactError convert(LibMseed.nstime_t, LibMseed.NanosecondDateTime("3000-01-01T00:00:00.000000000"))
+            @test_throws InexactError convert(LibMseed.nstime_t, LibMseed.NanosecondDateTime("1500-01-01T00:00:00.000000000"))
         end
 
         @testset "Conversion to DateTime" begin


### PR DESCRIPTION
`NanosecondDateTime`s in LibMseed.jl might have any value that a `DateTime` can have, but since libmseed's dates are in ns since the epoch, `NanosecondDateTime`s shouldn't be able to represent that.  Make sure that they cannot, and avoid wraparound when converting a `NanosecondDateTime` to the libsmeed `nstime_t` type, which is just an `Int64`.